### PR TITLE
Remove <U+2028>

### DIFF
--- a/02/rwd-site-initial.html
+++ b/02/rwd-site-initial.html
@@ -62,7 +62,7 @@
                         Since 2012, ’Responsive Web Design with HTML5 and CSS’
                         by Ben Frain, has been Packt publishing’s best-selling
                         book on Responsive Web Design and the latest HTML and
-                        CSS techniques and features.  Now completely updated 3rd
+                        CSS techniques and features. Now completely updated 3rd
                         Edition for 2020!
                     </p>
                     <a href="#new" class="rwd-Hero_JumpLink"

--- a/05/Start/index.html
+++ b/05/Start/index.html
@@ -67,7 +67,7 @@
                         Since 2012, ’Responsive Web Design with HTML5 and CSS’
                         by Ben Frain, has been Packt publishing’s best-selling
                         book on Responsive Web Design and the latest HTML and
-                        CSS techniques and features.  Now completely updated 3rd
+                        CSS techniques and features. Now completely updated 3rd
                         Edition for 2020!
                     </p>
                     <a href="#new" class="rwd-Hero_JumpLink"


### PR DESCRIPTION
Somehow these strange <U+2028> characters sneaked into the code. I removed them.

I don't think they are visible in the github diffs. But vs code complained about them. In a terminal `git show` gives:
```

-   CSS techniques and features. <U+2028>Now completely updated 3rd
+   CSS techniques and features. Now completely updated 3rd
```