### PR TITLE
fix: correct HTML tag mismatch in Strap class for heading

### DIFF
--- a/01/start/index.html
+++ b/01/start/index.html
@@ -14,7 +14,7 @@
             <a href="/" class="LogoWrapper"
                 ><img src="img/SOC-Logo.png" alt="Scone O'Clock logo"
             /></a>
-            <h1 class="Strap">Scones: the most resplendent of snacks</p>
+            <h1 class="Strap">Scones: the most resplendent of snacks</h1>
         </div>
         <div class="IntroWrapper">
             <h2 class="IntroText">


### PR DESCRIPTION
Replaced closing `<p>` tag with `<h1>` to properly close the header structure in Strap class.